### PR TITLE
rr-218-semaphore-auto-cancel

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,6 +4,9 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+auto_cancel:
+  running:
+    when: "true"
 fail_fast:
   stop:
     when: "branch != 'master' AND branch != 'skipff$'"


### PR DESCRIPTION
[[rr-218] CI/CD > Semaphore > Auto-cancel](https://app.asana.com/0/0/1135059701183210)


**Migrations**: Yes or No
**New translations**: Yes or No
**To be deployed with**: course-builder, course-player, course-player-v2, webhooks or None (link to corresponding PRs)
**Must run rake task**: rake name_of:the_rake_task or No

Deployment Checklist (make sure to check each one of the items before moving forward with the deployment):
- [ ] I have a rollback plan in case anything go wrong to quickly recover the app
- [ ] I'm in the working hours window (8AM - 5PM PST, Monday to Friday) or it is a hotfix
- [ ] I know who the point people are and I can reach them in case something goes wrong
- [ ] There are no webinars or demos going on