### PR TITLE
rr-213-ci-cd-semaphore-fail-fast-fix-the-skip

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,7 +9,7 @@ auto_cancel:
     when: "true"
 fail_fast:
   stop:
-    when: "branch != 'master' AND branch != 'skipff$'"
+    when: "branch != 'master' AND branch !~ 'skipff$'"
 blocks:
   - name: "tests"
     task:


### PR DESCRIPTION
[[rr-213] CI/CD > Semaphore > Fail-fast](https://app.asana.com/0/0/1135059701183211)


Tiny operator change! skipping fail fast didn't work and this should fix it!
Double tested by Kevin and myself!

Deployment Checklist (make sure to check each one of the items before moving forward with the deployment):
- [ ] I have a rollback plan in case anything go wrong to quickly recover the app
- [ ] I'm in the working hours window (8AM - 5PM PST, Monday to Friday) or it is a hotfix
- [ ] I know who the point people are and I can reach them in case something goes wrong
- [ ] There are no webinars or demos going on