### PR TITLE
Fix Ruby 3 incompatibility when setting ENV because of how hash.each yielding changed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cloud_secret_env (0.1.4)
+    cloud_secret_env (0.1.5)
       aws-sdk-core (~> 3)
       aws-sdk-secretsmanager (~> 1)
 
@@ -9,18 +9,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    aws-eventstream (1.0.3)
-    aws-partitions (1.269.0)
-    aws-sdk-core (3.89.1)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.390.0)
+    aws-sdk-core (3.109.2)
+      aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-secretsmanager (1.32.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-secretsmanager (1.43.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     coderay (1.1.2)
     diff-lcs (1.3)
     jaro_winkler (1.5.3)

--- a/lib/cloud_secret_env.rb
+++ b/lib/cloud_secret_env.rb
@@ -42,7 +42,7 @@ module CloudSecretEnv
         block = if @config.override
                   ->(pair) { ENV[pair[0]] = pair[1] }
                 else
-                  ->(pair) { ENV[pair[0]] = pair[1] unless ENV[pair[1]] }
+                  ->(pair) { ENV[pair[0]] = pair[1] unless ENV[pair[0]] }
                 end
         secrets.each(&block)
       end

--- a/lib/cloud_secret_env.rb
+++ b/lib/cloud_secret_env.rb
@@ -40,9 +40,9 @@ module CloudSecretEnv
 
       def push_env!(secrets)
         block = if @config.override
-                  ->(k, v) { ENV[k] = v }
+                  ->(pair) { ENV[pair[0]] = pair[1] }
                 else
-                  ->(k, v) { ENV[k] = v unless ENV[k] }
+                  ->(pair) { ENV[pair[0]] = pair[1] unless ENV[pair[1]] }
                 end
         secrets.each(&block)
       end

--- a/lib/cloud_secret_env/version.rb
+++ b/lib/cloud_secret_env/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloudSecretEnv
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Ruby 3 changed how `Hash#each` yields to lambdas which resulted in the error below when using this gem in a Ruby 3.1 app. This fix simply changes the lambda to expect a single 2-dimensional array that's the key value pair instead. This change was tested locally using `bundle exec rake` in both Ruby 2.6.6 and 3.1.0 and tests passed.

```
eval error: wrong number of arguments (given 1, expected 2)
  (rdbg)//Users/ryan/.asdf/installs/ruby/3.1.0/lib/ruby/gems/3.1.0/bundler/gems/cloud-secret-env-279d4027ab2e/lib/cloud_secret_env.rb:1:in `block in push_env!' 
  ```

**Changelog and discussion around the change:**
- https://rubyreferences.github.io/rubychanges/3.0.html#hasheach-consistently-yields-a-2-element-array-to-lambdas 
- https://bugs.ruby-lang.org/issues/16260

**Edit:** Looks like the automation running on Semaphore is breaking, doesn't seem related to my changes though. Seems like Semaphore doesn't have permission to pull this repo.