### PR TITLE
fix(Ruby3): Adds compatibility for Ruby3

### DIFF
--- a/lib/cloud_secret_env.rb
+++ b/lib/cloud_secret_env.rb
@@ -40,11 +40,11 @@ module CloudSecretEnv
 
       def push_env!(secrets)
         block = if @config.override
-                  ->(pair) { ENV[pair[0]] = pair[1] }
+                  ->(key, value) { ENV[key] = value }
                 else
-                  ->(pair) { ENV[pair[0]] = pair[1] unless ENV[pair[0]] }
+                  ->(key, value) { ENV[key] = value unless ENV[key] }
                 end
-        secrets.each(&block)
+        secrets.each { |key, value| block.call(key, value) }
       end
   end
 end


### PR DESCRIPTION
Hello!
This library is used in a few engines and gems to pull secrets from AWS. This library is working fine in Ruby 2.7, but it doesn't seem to work in Ruby 3.1

This PR contains a small fix that addresses the incompatibility in Ruby 3.1, to make the code compatible with both Ruby versions.

The issue comes on the way on how Hash.each spreads the arguments to a block passed by parameter. This issue is described [here](https://docs.gitlab.com/ee/development/ruby3_gotchas.html#hasheach-consistently-yields-a-2-element-array-to-lambdas).

In Ruby 2.7, we can call `hash.each(&block)` and the lambda method can have multiple arguments. 

![image](https://github.com/thinkific/cloud-secret-env/assets/3863852/0eb7936a-4bfd-4610-a179-565b2ac67641)

In Ruby 3, we can't call `hash.each(&block)` when the lambda has multiple arguments. 

![image](https://github.com/thinkific/cloud-secret-env/assets/3863852/08374a95-ee14-4261-8b3d-5b7f1b9db0da)

The easiest fix is to write an each statement and deconstruct the arguments as expected:

```ruby
hash.each do |key, value|
   ...
end
```

This has been causing many Enginers and Gems RSpecs to fail when running on Ruby 3.1 since they can't pull these secrets. [This is an example](https://thinkific.semaphoreci.com/jobs/5de86ed1-ba49-455a-ae81-655f59851c14#L5465).

![image](https://github.com/thinkific/cloud-secret-env/assets/3863852/19891bc9-60ed-411d-b20a-f08ed1a0582a)
